### PR TITLE
Fix: Corregir relación TypeORM en PromocionUso

### DIFF
--- a/src/promociones/entities/promocion.entity.ts
+++ b/src/promociones/entities/promocion.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
 import { BaseEntity } from '../../common/entities/base.entity';
 
 export enum TipoPromocion {
@@ -247,7 +247,8 @@ export class PromocionUso extends BaseEntity {
   codigoUsado?: string;
 
   // Relaciones
-  @Column()
+  @ManyToOne(() => Promocion, promocion => promocion.usos)
+  @JoinColumn({ name: 'promocionId' })
   promocion: Promocion;
 
   // @ManyToOne(() => Venta, venta => venta.promocionesUsadas)
@@ -258,4 +259,3 @@ export class PromocionUso extends BaseEntity {
   // @JoinColumn({ name: 'clienteId' })
   // cliente: Cliente;
 }
-


### PR DESCRIPTION
- Cambiar @Column() por @ManyToOne() en PromocionUso.promocion
- Agregar @JoinColumn para la relación correcta
- Resolver error 'Data type Promocion not supported by postgres'
- El servidor ahora compila y se inicia correctamente
- Solo falta configurar la conexión a PostgreSQL en .env